### PR TITLE
Connect actors directly with minimal indirections

### DIFF
--- a/crates/bin/c8y_configuration_poc/src/file_system_ext.rs
+++ b/crates/bin/c8y_configuration_poc/src/file_system_ext.rs
@@ -5,6 +5,7 @@ use tedge_actors::ActorBuilder;
 use tedge_actors::ChannelError;
 use tedge_actors::DynSender;
 use tedge_actors::MessageBox;
+use tedge_actors::MessageSource;
 use tedge_actors::RuntimeError;
 use tedge_actors::RuntimeHandle;
 use tedge_utils::notify::FsEvent;
@@ -82,6 +83,12 @@ impl FsWatchActorBuilder {
 impl FsWatchActorBuilder {
     pub fn new_watcher(&mut self, watch_path: PathBuf, peer_sender: DynSender<FsWatchEvent>) {
         self.watch_dirs.push((watch_path, peer_sender));
+    }
+}
+
+impl MessageSource<FsWatchEvent, PathBuf> for FsWatchActorBuilder {
+    fn register_peer(&mut self, config: PathBuf, sender: DynSender<FsWatchEvent>) {
+        self.watch_dirs.push((config, sender));
     }
 }
 

--- a/crates/core/tedge_actors/src/message_boxes.rs
+++ b/crates/core/tedge_actors/src/message_boxes.rs
@@ -70,6 +70,19 @@ pub trait MessageBox: 'static + Sized + Send + Sync {
     fn logging_is_on(&self) -> bool;
 }
 
+// A MessageBox must implement this trait for every message type that can be sent to it
+pub trait MessageSink<M: Message> {
+    // Return the sender that can be used by peers to send messages to this actor
+    fn get_sender(&mut self) -> DynSender<M>;
+}
+
+pub struct NoConfig {}
+// A MessageBox must implement this trait for every message type that it can receive from its peers
+pub trait MessageSource<M: Message, Config> {
+    // The message will be sent to the peer using the provided `sender`
+    fn register_peer(&mut self, config: Config, sender: DynSender<M>);
+}
+
 /// The basic message box
 pub struct SimpleMessageBox<Input, Output> {
     name: String,

--- a/crates/extensions/tedge_mqtt_ext/src/lib.rs
+++ b/crates/extensions/tedge_mqtt_ext/src/lib.rs
@@ -16,6 +16,8 @@ use tedge_actors::DynSender;
 use tedge_actors::MessageBox;
 use tedge_actors::MessageBoxConnector;
 use tedge_actors::MessageBoxPort;
+use tedge_actors::MessageSink;
+use tedge_actors::MessageSource;
 use tedge_actors::RuntimeError;
 use tedge_actors::RuntimeHandle;
 
@@ -61,6 +63,18 @@ impl MessageBoxConnector<MqttMessage, MqttMessage, TopicFilter> for MqttActorBui
         self.subscriber_addresses
             .push((subscriptions, peer.get_response_sender()));
         peer.set_request_sender(self.publish_channel.0.clone().into())
+    }
+}
+
+impl MessageSource<MqttMessage, TopicFilter> for MqttActorBuilder {
+    fn register_peer(&mut self, subscriptions: TopicFilter, sender: DynSender<MqttMessage>) {
+        self.subscriber_addresses.push((subscriptions, sender));
+    }
+}
+
+impl MessageSink<MqttMessage> for MqttActorBuilder {
+    fn get_sender(&mut self) -> DynSender<MqttMessage> {
+        self.publish_channel.0.clone().into()
     }
 }
 


### PR DESCRIPTION
## Proposed changes

1.  Split the `MessageBoxPort` concept into `MessageSource` and `MessageSink` concepts as not every actor has symmetric requests and responses (e.g: `FsWatchActor`)
2. Avoid `MessageBoxConnector` indirection while connecting actors, to simplify the code.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [ ] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [ ] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

