### PR TITLE
Child device config management handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -521,6 +521,7 @@ dependencies = [
  "tedge_http_ext",
  "tedge_mqtt_ext",
  "tedge_signal_ext",
+ "tedge_timer_ext",
  "tedge_utils",
  "thiserror",
  "tokio",

--- a/crates/bin/c8y_configuration_poc/Cargo.toml
+++ b/crates/bin/c8y_configuration_poc/Cargo.toml
@@ -23,6 +23,7 @@ tedge_config = { path = "../../common/tedge_config" }
 tedge_http_ext = { path = "../../extensions/tedge_http_ext" }
 tedge_mqtt_ext = { path = "../../extensions/tedge_mqtt_ext" }
 tedge_signal_ext = { path = "../../extensions/tedge_signal_ext" }
+tedge_timer_ext = { path = "../../extensions/tedge_timer_ext" }
 tedge_utils = { path = "../../common/tedge_utils", features = ["fs-notify"] }
 thiserror = "1.0"
 tokio = { version = "1.23", features = ["rt", "rt-multi-thread"] }

--- a/crates/bin/c8y_configuration_poc/src/config_manager/child_device.rs
+++ b/crates/bin/c8y_configuration_poc/src/config_manager/child_device.rs
@@ -1,3 +1,4 @@
+use super::actor::ConfigOperation;
 use super::error::ConfigManagementError;
 use super::plugin_config::FileEntry;
 use c8y_api::smartrest::topic::C8yTopic;
@@ -5,14 +6,15 @@ use mqtt_channel::Message;
 use mqtt_channel::Topic;
 use mqtt_channel::TopicFilter;
 use std::fs;
+use std::time::Duration;
 use tedge_api::OperationStatus;
 use tracing::error;
 
-// FIXME move this to tedge config
 #[cfg(test)]
 pub const FILE_TRANSFER_ROOT_PATH: &str = "/tmp";
 #[cfg(not(test))]
 pub const FILE_TRANSFER_ROOT_PATH: &str = "/var/tedge/file-transfer";
+pub const DEFAULT_OPERATION_TIMEOUT: Duration = Duration::from_secs(60); //TODO: Make this configurable?
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum ConfigOperationResponseTopic {
@@ -284,4 +286,11 @@ pub struct ChildDeviceRequestPayload {
     pub path: String,
     #[serde(rename = "type")]
     pub config_type: Option<String>,
+}
+
+#[derive(Debug, PartialEq, Eq, Hash, Clone)]
+pub struct ChildConfigOperationKey {
+    pub child_id: String,
+    pub operation_type: ConfigOperation,
+    pub config_type: String,
 }

--- a/crates/bin/c8y_configuration_poc/src/config_manager/child_device.rs
+++ b/crates/bin/c8y_configuration_poc/src/config_manager/child_device.rs
@@ -1,0 +1,287 @@
+use super::error::ConfigManagementError;
+use super::plugin_config::FileEntry;
+use c8y_api::smartrest::topic::C8yTopic;
+use mqtt_channel::Message;
+use mqtt_channel::Topic;
+use mqtt_channel::TopicFilter;
+use std::fs;
+use tedge_api::OperationStatus;
+use tracing::error;
+
+// FIXME move this to tedge config
+#[cfg(test)]
+pub const FILE_TRANSFER_ROOT_PATH: &str = "/tmp";
+#[cfg(not(test))]
+pub const FILE_TRANSFER_ROOT_PATH: &str = "/var/tedge/file-transfer";
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub enum ConfigOperationResponseTopic {
+    SnapshotResponse,
+    UpdateResponse,
+}
+
+#[allow(clippy::from_over_into)]
+// can not implement From since the topic can be anything (`new_unchecked` can be any &str)
+impl Into<TopicFilter> for ConfigOperationResponseTopic {
+    fn into(self) -> TopicFilter {
+        match self {
+            ConfigOperationResponseTopic::SnapshotResponse => {
+                TopicFilter::new_unchecked("tedge/+/commands/res/config_snapshot")
+            }
+            ConfigOperationResponseTopic::UpdateResponse => {
+                TopicFilter::new_unchecked("tedge/+/commands/res/config_update")
+            }
+        }
+    }
+}
+
+pub trait ConfigOperationMessage {
+    fn http_file_repository_relative_path(&self) -> String;
+
+    fn file_transfer_repository_full_path(&self) -> String {
+        format!(
+            "{FILE_TRANSFER_ROOT_PATH}/{}",
+            self.http_file_repository_relative_path()
+        )
+    }
+}
+
+/// A child device can receive the following operation requests:
+///
+/// - Update:
+///
+///     An operation that requests the child device to update its configuration with an update from the cloud.
+///
+/// - Snapshot:
+///
+///     An operation that requests the child device to upload its current configuration snapshot to the cloud.
+pub enum ConfigOperationRequest {
+    Update {
+        child_id: String,
+        file_entry: FileEntry,
+    },
+    Snapshot {
+        child_id: String,
+        file_entry: FileEntry,
+    },
+}
+
+pub enum ConfigOperationResponse {
+    Update {
+        child_id: String,
+        payload: ChildDeviceResponsePayload,
+    },
+    Snapshot {
+        child_id: String,
+        payload: ChildDeviceResponsePayload,
+    },
+}
+
+impl ConfigOperationResponse {
+    pub fn get_child_id(&self) -> String {
+        match self {
+            ConfigOperationResponse::Update { child_id, .. } => child_id.to_string(),
+            ConfigOperationResponse::Snapshot { child_id, .. } => child_id.to_string(),
+        }
+    }
+
+    pub fn get_config_type(&self) -> String {
+        match self {
+            ConfigOperationResponse::Update { payload, .. } => payload.config_type.to_string(),
+            ConfigOperationResponse::Snapshot { payload, .. } => payload.config_type.to_string(),
+        }
+    }
+
+    pub fn get_child_topic(&self) -> String {
+        match self {
+            ConfigOperationResponse::Update { child_id, .. } => {
+                C8yTopic::ChildSmartRestResponse(child_id.to_owned()).to_string()
+            }
+            ConfigOperationResponse::Snapshot { child_id, .. } => {
+                C8yTopic::ChildSmartRestResponse(child_id.to_owned()).to_string()
+            }
+        }
+    }
+
+    pub fn get_payload(&self) -> &ChildDeviceResponsePayload {
+        match self {
+            ConfigOperationResponse::Update { payload, .. } => payload,
+            ConfigOperationResponse::Snapshot { payload, .. } => payload,
+        }
+    }
+}
+
+impl ConfigOperationMessage for ConfigOperationResponse {
+    fn http_file_repository_relative_path(&self) -> String {
+        match self {
+            ConfigOperationResponse::Update {
+                child_id, payload, ..
+            } => {
+                format!("{}/config_update/{}", child_id, payload.config_type)
+            }
+            ConfigOperationResponse::Snapshot {
+                child_id, payload, ..
+            } => {
+                format!("{}/config_snapshot/{}", child_id, payload.config_type)
+            }
+        }
+    }
+}
+
+pub fn try_cleanup_config_file_from_file_transfer_repositoy(
+    config_response: &ConfigOperationResponse,
+) {
+    let config_file_path = config_response.file_transfer_repository_full_path();
+    if let Err(err) = fs::remove_file(&config_file_path) {
+        error!(
+            "Failed to remove config file file copy at {} with {}",
+            config_file_path, err
+        );
+    }
+}
+
+/// Return child id from topic.
+pub fn get_child_id_from_child_topic(topic: &str) -> Result<String, ConfigManagementError> {
+    let mut topic_split = topic.split('/');
+    // the second element is the child id
+    let child_id = topic_split
+        .nth(1)
+        .ok_or(ConfigManagementError::InvalidChildDeviceTopic {
+            topic: topic.into(),
+        })?;
+    Ok(child_id.to_string())
+}
+
+/// Return operation name from topic.
+pub fn get_operation_name_from_child_topic(topic: &str) -> Result<String, ConfigManagementError> {
+    let topic_split = topic.split('/');
+    let operation_name =
+        topic_split
+            .last()
+            .ok_or(ConfigManagementError::InvalidChildDeviceTopic {
+                topic: topic.into(),
+            })?;
+    Ok(operation_name.to_string())
+}
+impl TryFrom<&Message> for ConfigOperationResponse {
+    type Error = ConfigManagementError;
+
+    fn try_from(message: &Message) -> Result<Self, Self::Error> {
+        let topic = &message.topic.name;
+        let child_id = get_child_id_from_child_topic(topic)?;
+        let operation_name = get_operation_name_from_child_topic(topic)?;
+
+        let request_payload: ChildDeviceResponsePayload =
+            serde_json::from_str(message.payload_str()?)?;
+
+        if operation_name == "config_snapshot" {
+            return Ok(Self::Snapshot {
+                child_id,
+                payload: request_payload,
+            });
+        }
+        if operation_name == "config_update" {
+            return Ok(Self::Update {
+                child_id,
+                payload: request_payload,
+            });
+        }
+        Err(ConfigManagementError::InvalidChildDeviceTopic {
+            topic: topic.to_string(),
+        })
+    }
+}
+
+impl ConfigOperationRequest {
+    /// The configuration management topic for a child device.
+    ///
+    /// # Example:
+    /// For a configuration update returns:
+    ///     - "tedge/CHILD_ID/commands/req/config_update"
+    ///
+    /// For a configuration snapshot returns:
+    ///     - "tedge/CHILD_ID/commands/req/config_snapshot"
+    pub fn operation_request_topic(&self) -> Topic {
+        match self {
+            ConfigOperationRequest::Update { child_id, .. } => {
+                Topic::new_unchecked(&format!("tedge/{}/commands/req/config_update", child_id))
+            }
+            ConfigOperationRequest::Snapshot { child_id, .. } => {
+                Topic::new_unchecked(&format!("tedge/{}/commands/req/config_snapshot", child_id))
+            }
+        }
+    }
+
+    /// The configuration management payload for a child device.
+    pub fn operation_request_payload(
+        &self,
+        local_http_host: &str,
+    ) -> Result<String, ConfigManagementError> {
+        let url = format!(
+            "http://{local_http_host}/tedge/file-transfer/{}",
+            self.http_file_repository_relative_path()
+        );
+        match self {
+            ConfigOperationRequest::Update {
+                child_id: _,
+                file_entry,
+            } => {
+                let request = ChildDeviceRequestPayload {
+                    url,
+                    path: file_entry.path.clone(),
+                    config_type: Some(file_entry.config_type.clone()),
+                };
+                Ok(serde_json::to_string(&request)?)
+            }
+            ConfigOperationRequest::Snapshot {
+                child_id: _,
+                file_entry,
+            } => {
+                let request = ChildDeviceRequestPayload {
+                    url,
+                    path: file_entry.path.clone(),
+                    config_type: Some(file_entry.config_type.clone()),
+                };
+                Ok(serde_json::to_string(&request)?)
+            }
+        }
+    }
+}
+
+impl ConfigOperationMessage for ConfigOperationRequest {
+    fn http_file_repository_relative_path(&self) -> String {
+        match self {
+            ConfigOperationRequest::Update {
+                child_id,
+                file_entry,
+                ..
+            } => {
+                format!("{}/config_update/{}", child_id, file_entry.config_type)
+            }
+            ConfigOperationRequest::Snapshot {
+                child_id,
+                file_entry,
+                ..
+            } => {
+                format!("{}/config_snapshot/{}", child_id, file_entry.config_type)
+            }
+        }
+    }
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+pub struct ChildDeviceResponsePayload {
+    pub status: Option<OperationStatus>,
+    pub path: String,
+    #[serde(rename = "type")]
+    pub config_type: String,
+    pub reason: Option<String>,
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+pub struct ChildDeviceRequestPayload {
+    pub url: String,
+    pub path: String,
+    #[serde(rename = "type")]
+    pub config_type: Option<String>,
+}

--- a/crates/bin/c8y_configuration_poc/src/config_manager/download.rs
+++ b/crates/bin/c8y_configuration_poc/src/config_manager/download.rs
@@ -1,5 +1,11 @@
+use crate::config_manager::child_device::ChildConfigOperationKey;
+use crate::config_manager::child_device::DEFAULT_OPERATION_TIMEOUT;
+
 use super::actor::ActiveOperationState;
+use super::actor::ConfigManagerActor;
 use super::actor::ConfigManagerMessageBox;
+use super::actor::ConfigOperation;
+use super::actor::OperationTimeout;
 use super::child_device::try_cleanup_config_file_from_file_transfer_repositoy;
 use super::child_device::ConfigOperationMessage;
 use super::child_device::ConfigOperationRequest;
@@ -18,7 +24,6 @@ use c8y_api::smartrest::smartrest_serializer::SmartRestSetOperationToExecuting;
 use c8y_api::smartrest::smartrest_serializer::SmartRestSetOperationToFailed;
 use c8y_api::smartrest::smartrest_serializer::SmartRestSetOperationToSuccessful;
 use c8y_api::smartrest::smartrest_serializer::TryIntoOperationStatusMessage;
-use c8y_api::smartrest::topic::C8yTopic;
 use mqtt_channel::Message;
 use mqtt_channel::Topic;
 use serde_json::json;
@@ -26,6 +31,7 @@ use std::collections::HashMap;
 use std::path::Path;
 use std::path::PathBuf;
 use tedge_api::OperationStatus;
+use tedge_timer_ext::SetTimeout;
 use tedge_utils::file::PermissionEntry;
 use tracing::error;
 use tracing::info;
@@ -35,7 +41,7 @@ pub const CONFIG_CHANGE_TOPIC: &str = "tedge/configuration_change";
 
 pub struct ConfigDownloadManager {
     config: ConfigManagerConfig,
-    active_child_ops: HashMap<(String, String), ActiveOperationState>,
+    active_child_ops: HashMap<ChildConfigOperationKey, ActiveOperationState>,
 }
 
 impl ConfigDownloadManager {
@@ -150,6 +156,12 @@ impl ConfigDownloadManager {
         let child_id = smartrest_request.device;
         let config_type = smartrest_request.config_type;
 
+        let operation_key = ChildConfigOperationKey {
+            child_id: child_id.clone(),
+            operation_type: ConfigOperation::Update,
+            config_type: config_type.clone(),
+        };
+
         let plugin_config = PluginConfig::new(Path::new(&format!(
             "{}/c8y/{child_id}/{DEFAULT_PLUGIN_CONFIG_FILE_NAME}",
             self.config.config_dir.display(),
@@ -176,36 +188,34 @@ impl ConfigDownloadManager {
                     // Fail the operation in the cloud if the file download itself fails
                     // by sending EXECUTING and FAILED responses back to back
 
-                    let c8y_child_topic = Topic::new_unchecked(
-                        &C8yTopic::ChildSmartRestResponse(child_id).to_string(),
-                    );
-
-                    let executing_msg = Message::new(
-                        &c8y_child_topic,
-                        DownloadConfigFileStatusMessage::status_executing()?,
-                    );
-                    message_box.send(executing_msg).await?;
-
                     let failure_reason = format!(
                         "Downloading the config file update from {} failed with {}",
                         smartrest_request.url, err
                     );
-                    let failed_msg = Message::new(
-                        &c8y_child_topic,
-                        DownloadConfigFileStatusMessage::status_failed(failure_reason)?,
-                    );
-                    message_box.send(failed_msg).await?;
+                    ConfigManagerActor::fail_config_operation_in_c8y(
+                        ConfigOperation::Update,
+                        Some(child_id),
+                        ActiveOperationState::Pending,
+                        failure_reason,
+                        message_box,
+                    )
+                    .await?;
                 } else {
                     let config_update_req_msg = Message::new(
                         &config_management.operation_request_topic(),
                         config_management
                             .operation_request_payload(&self.config.tedge_http_host)?,
                     );
-                    message_box.send(config_update_req_msg).await?;
+                    message_box.send(config_update_req_msg.into()).await?;
                     info!("Config update request for config type: {config_type} sent to child device: {child_id}");
 
                     self.active_child_ops
-                        .insert((child_id, config_type), ActiveOperationState::Pending);
+                        .insert(operation_key.clone(), ActiveOperationState::Pending);
+
+                    // Start the timer for operation timeout
+                    message_box
+                        .send(SetTimeout::new(DEFAULT_OPERATION_TIMEOUT, operation_key).into())
+                        .await?;
                 }
             }
             Err(ConfigManagementError::InvalidRequestedConfigType { config_type }) => {
@@ -219,20 +229,26 @@ impl ConfigDownloadManager {
         Ok(())
     }
 
-    pub fn handle_child_device_config_update_response(
+    pub async fn handle_child_device_config_update_response(
         &mut self,
         config_response: &ConfigOperationResponse,
+        message_box: &mut ConfigManagerMessageBox,
     ) -> Result<Vec<Message>, ConfigManagementError> {
         let c8y_child_topic = Topic::new_unchecked(&config_response.get_child_topic());
         let child_device_payload = config_response.get_payload();
         let child_id = config_response.get_child_id();
         let config_type = config_response.get_config_type();
+        let operation_key = ChildConfigOperationKey {
+            child_id: child_id.clone(),
+            operation_type: ConfigOperation::Update,
+            config_type: config_type.clone(),
+        };
 
         info!("Config update response received for type: {config_type} from child: {child_id}");
 
         let mut mapped_responses = vec![];
         if let Some(operation_status) = child_device_payload.status {
-            let current_operation_state = self.active_child_ops.get(&(child_id, config_type));
+            let current_operation_state = self.active_child_ops.get(&operation_key);
             if current_operation_state != Some(&ActiveOperationState::Executing) {
                 let executing_status_payload = DownloadConfigFileStatusMessage::status_executing()?;
                 mapped_responses.push(Message::new(&c8y_child_topic, executing_status_payload));
@@ -240,7 +256,7 @@ impl ConfigDownloadManager {
 
             match operation_status {
                 OperationStatus::Successful => {
-                    // self.operation_timer.stop_timer(operation_key);
+                    self.active_child_ops.remove(&operation_key);
 
                     // Cleanup the downloaded file after the operation completes
                     try_cleanup_config_file_from_file_transfer_repositoy(config_response);
@@ -250,7 +266,7 @@ impl ConfigDownloadManager {
                         .push(Message::new(&c8y_child_topic, successful_status_payload));
                 }
                 OperationStatus::Failed => {
-                    // self.operation_timer.stop_timer(operation_key);
+                    self.active_child_ops.remove(&operation_key);
 
                     // Cleanup the downloaded file after the operation completes
                     try_cleanup_config_file_from_file_transfer_repositoy(config_response);
@@ -269,17 +285,46 @@ impl ConfigDownloadManager {
                     }
                 }
                 OperationStatus::Executing => {
-                    // self.operation_timer.start_timer(
-                    //     operation_key,
-                    //     ActiveOperationState::Executing,
-                    //     DEFAULT_OPERATION_TIMEOUT,
-                    // );
+                    self.active_child_ops
+                        .insert(operation_key.clone(), ActiveOperationState::Executing);
+
+                    // Reset the timer
+                    message_box
+                        .send(SetTimeout::new(DEFAULT_OPERATION_TIMEOUT, operation_key).into())
+                        .await?;
                 }
             }
 
             Ok(mapped_responses)
         } else {
             Err(ConfigManagementError::EmptyOperationStatus(c8y_child_topic))
+        }
+    }
+
+    pub async fn process_operation_timeout(
+        &mut self,
+        timeout: OperationTimeout,
+        message_box: &mut ConfigManagerMessageBox,
+    ) -> Result<(), anyhow::Error> {
+        let child_id = timeout.event.child_id;
+        let config_type = timeout.event.config_type;
+        let operation_key = ChildConfigOperationKey {
+            child_id: child_id.clone(),
+            operation_type: ConfigOperation::Update,
+            config_type: config_type.clone(),
+        };
+
+        if let Some(operation_state) = self.active_child_ops.remove(&operation_key) {
+            ConfigManagerActor::fail_config_operation_in_c8y(
+                ConfigOperation::Update,
+                Some(child_id.clone()),
+                operation_state,
+                format!("Timeout due to lack of response from child device: {child_id} for config type: {config_type}"),
+                message_box,
+            ).await
+        } else {
+            // Ignore the timeout as the operation has already completed.
+            Ok(())
         }
     }
 }

--- a/crates/bin/c8y_configuration_poc/src/config_manager/error.rs
+++ b/crates/bin/c8y_configuration_poc/src/config_manager/error.rs
@@ -35,4 +35,7 @@ pub enum ConfigManagementError {
 
     #[error("Failed to parse response from child device with: {0}")]
     FromSerdeJsonError(#[from] serde_json::Error),
+
+    #[error(transparent)]
+    FromChannelError(#[from] tedge_actors::ChannelError),
 }

--- a/crates/bin/c8y_configuration_poc/src/config_manager/error.rs
+++ b/crates/bin/c8y_configuration_poc/src/config_manager/error.rs
@@ -1,3 +1,4 @@
+use mqtt_channel::Topic;
 use std::io;
 use tedge_utils::file::FileError;
 
@@ -7,6 +8,12 @@ pub enum ConfigManagementError {
         "The requested config_type {config_type} is not defined in the plugin configuration file."
     )]
     InvalidRequestedConfigType { config_type: String },
+
+    #[error("Message received on invalid topic from child device: {topic}")]
+    InvalidChildDeviceTopic { topic: String },
+
+    #[error("Invalid operation response with empty status received on topic: {0:?}")]
+    EmptyOperationStatus(Topic),
 
     #[error(transparent)]
     FromTEdgeConfig(#[from] tedge_config::TEdgeConfigError),
@@ -19,4 +26,13 @@ pub enum ConfigManagementError {
 
     #[error(transparent)]
     FromIoError(#[from] io::Error),
+
+    #[error(transparent)]
+    FromMqttError(#[from] mqtt_channel::MqttError),
+
+    #[error(transparent)]
+    FromSmartRestSerializerError(#[from] c8y_api::smartrest::error::SmartRestSerializerError),
+
+    #[error("Failed to parse response from child device with: {0}")]
+    FromSerdeJsonError(#[from] serde_json::Error),
 }

--- a/crates/bin/c8y_configuration_poc/src/config_manager/error.rs
+++ b/crates/bin/c8y_configuration_poc/src/config_manager/error.rs
@@ -2,6 +2,7 @@ use mqtt_channel::Topic;
 use std::io;
 use tedge_utils::file::FileError;
 
+#[allow(clippy::large_enum_variant)]
 #[derive(thiserror::Error, Debug)]
 pub enum ConfigManagementError {
     #[error(

--- a/crates/bin/c8y_configuration_poc/src/config_manager/mod.rs
+++ b/crates/bin/c8y_configuration_poc/src/config_manager/mod.rs
@@ -1,4 +1,5 @@
 mod actor;
+mod child_device;
 mod config;
 mod download;
 mod error;

--- a/crates/bin/c8y_configuration_poc/src/config_manager/upload.rs
+++ b/crates/bin/c8y_configuration_poc/src/config_manager/upload.rs
@@ -1,4 +1,11 @@
+use crate::config_manager::child_device::try_cleanup_config_file_from_file_transfer_repositoy;
+use crate::config_manager::child_device::ConfigOperationMessage;
+
+use super::actor::ActiveOperationState;
 use super::actor::ConfigManagerMessageBox;
+use super::child_device::ConfigOperationRequest;
+use super::child_device::ConfigOperationResponse;
+use super::error::ConfigManagementError;
 use super::plugin_config::PluginConfig;
 use super::ConfigManagerConfig;
 use anyhow::Result;
@@ -11,17 +18,29 @@ use c8y_api::smartrest::smartrest_serializer::SmartRestSetOperationToExecuting;
 use c8y_api::smartrest::smartrest_serializer::SmartRestSetOperationToFailed;
 use c8y_api::smartrest::smartrest_serializer::SmartRestSetOperationToSuccessful;
 use c8y_api::smartrest::smartrest_serializer::TryIntoOperationStatusMessage;
+use log::warn;
+use mqtt_channel::Message;
+use mqtt_channel::Topic;
+use std::collections::HashMap;
 use std::path::Path;
+use tedge_api::OperationStatus;
+use tedge_utils::file::create_directory_with_user_group;
+use tedge_utils::file::create_file_with_user_group;
 use tracing::error;
 use tracing::info;
 
 pub struct ConfigUploadManager {
     config: ConfigManagerConfig,
+    active_child_ops: HashMap<(String, String), ActiveOperationState>,
 }
 
 impl ConfigUploadManager {
     pub fn new(config: ConfigManagerConfig) -> Self {
-        ConfigUploadManager { config }
+        let active_child_ops = HashMap::new();
+        ConfigUploadManager {
+            config,
+            active_child_ops,
+        }
     }
 
     pub async fn handle_config_upload_request(
@@ -34,8 +53,13 @@ impl ConfigUploadManager {
             config_upload_request.config_type, config_upload_request.device
         );
 
-        self.handle_config_upload_request_tedge_device(config_upload_request, message_box)
-            .await
+        if config_upload_request.device == self.config.device_id {
+            self.handle_config_upload_request_tedge_device(config_upload_request, message_box)
+                .await
+        } else {
+            self.handle_config_upload_request_child_device(config_upload_request, message_box)
+                .await
+        }
     }
 
     pub async fn handle_config_upload_request_tedge_device(
@@ -56,6 +80,7 @@ impl ConfigUploadManager {
                     self.upload_config_file(
                         Path::new(config_file_path.as_str()),
                         &config_upload_request.config_type,
+                        None,
                         message_box,
                     )
                     .await
@@ -85,17 +110,228 @@ impl ConfigUploadManager {
         Ok(())
     }
 
+    /// Map the c8y_UploadConfigFile request into a tedge/commands/req/config_snapshot command for the child device.
+    /// The child device is expected to upload the config fie snapshot to the file transfer service.
+    /// A unique URL path for this config file, from the file transfer service, is shared with the child device in the command.
+    /// The child device can use this URL to upload the config file snapshot to the file transfer service.
+    pub async fn handle_config_upload_request_child_device(
+        &mut self,
+        config_upload_request: SmartRestConfigUploadRequest,
+        message_box: &mut ConfigManagerMessageBox,
+    ) -> Result<()> {
+        let child_id = config_upload_request.device;
+        let config_type = config_upload_request.config_type;
+
+        let plugin_config = PluginConfig::new(Path::new(&format!(
+            "{}/c8y/{child_id}/c8y-configuration-plugin.toml",
+            self.config.config_dir.display()
+        )));
+
+        match plugin_config.get_file_entry_from_type(&config_type) {
+            Ok(file_entry) => {
+                let config_management = ConfigOperationRequest::Snapshot {
+                    child_id: child_id.clone(),
+                    file_entry: file_entry.clone(),
+                };
+
+                let msg = Message::new(
+                    &config_management.operation_request_topic(),
+                    config_management.operation_request_payload(&self.config.tedge_http_host)?,
+                );
+                message_box.send(msg).await?;
+                info!("Config snapshot request for config type: {config_type} sent to child device: {child_id}");
+
+                self.active_child_ops
+                    .insert((child_id, config_type), ActiveOperationState::Pending);
+            }
+            Err(ConfigManagementError::InvalidRequestedConfigType { config_type }) => {
+                warn!(
+                    "Ignoring the config management request for unknown config type: {config_type}"
+                );
+            }
+            Err(err) => return Err(err)?,
+        }
+
+        Ok(())
+    }
+
+    pub async fn handle_child_device_config_snapshot_response(
+        &mut self,
+        config_response: &ConfigOperationResponse,
+        message_box: &mut ConfigManagerMessageBox,
+    ) -> Result<Vec<Message>, ConfigManagementError> {
+        let payload = config_response.get_payload();
+        let c8y_child_topic = Topic::new_unchecked(&config_response.get_child_topic());
+        let config_dir = self.config.config_dir.display();
+        let child_id = config_response.get_child_id();
+        let config_type = config_response.get_config_type();
+
+        info!("Config snapshot response received for type: {config_type} from child: {child_id}");
+
+        let mut mapped_responses = vec![];
+        if let Some(operation_status) = payload.status {
+            let current_operation_state = self.active_child_ops.get(&(child_id, config_type));
+            if current_operation_state != Some(&ActiveOperationState::Executing) {
+                let executing_status_payload = UploadConfigFileStatusMessage::status_executing()?;
+                mapped_responses.push(Message::new(&c8y_child_topic, executing_status_payload));
+            }
+
+            match operation_status {
+                OperationStatus::Successful => {
+                    // self.operation_timer.stop_timer(operation_key);
+
+                    match self
+                        .handle_child_device_successful_config_snapshot_response(
+                            config_response,
+                            message_box,
+                        )
+                        .await
+                    {
+                        Ok(message) => mapped_responses.push(message),
+                        Err(err) => {
+                            let failed_status_payload =
+                                UploadConfigFileStatusMessage::status_failed(err.to_string())?;
+                            mapped_responses
+                                .push(Message::new(&c8y_child_topic, failed_status_payload));
+                        }
+                    }
+                }
+                OperationStatus::Failed => {
+                    // self.operation_timer.stop_timer(operation_key);
+
+                    if let Some(error_message) = &payload.reason {
+                        let failed_status_payload = UploadConfigFileStatusMessage::status_failed(
+                            error_message.to_string(),
+                        )?;
+                        mapped_responses
+                            .push(Message::new(&c8y_child_topic, failed_status_payload));
+                    } else {
+                        let default_error_message =
+                            String::from("No failure reason provided by child device.");
+                        let failed_status_payload =
+                            UploadConfigFileStatusMessage::status_failed(default_error_message)?;
+                        mapped_responses
+                            .push(Message::new(&c8y_child_topic, failed_status_payload));
+                    }
+                }
+                OperationStatus::Executing => {
+                    // self.operation_timer.start_timer(
+                    //     operation_key,
+                    //     ActiveOperationState::Executing,
+                    //     DEFAULT_OPERATION_TIMEOUT,
+                    // );
+                }
+            }
+            Ok(mapped_responses)
+        } else {
+            if &config_response.get_config_type() == "c8y-configuration-plugin" {
+                // create directories
+                create_directory_with_user_group(
+                    format!("{}/c8y/{}", config_dir, config_response.get_child_id()),
+                    "tedge",
+                    "tedge",
+                    0o755,
+                )?;
+                create_directory_with_user_group(
+                    format!(
+                        "{}/operations/c8y/{}",
+                        config_dir,
+                        config_response.get_child_id()
+                    ),
+                    "tedge",
+                    "tedge",
+                    0o755,
+                )?;
+                create_file_with_user_group(
+                    format!(
+                        "{}/operations/c8y/{}/c8y_DownloadConfigFile",
+                        config_dir,
+                        config_response.get_child_id()
+                    ),
+                    "tedge",
+                    "tedge",
+                    0o755,
+                    None,
+                )?;
+                create_file_with_user_group(
+                    format!(
+                        "{}/operations/c8y/{}/c8y_UploadConfigFile",
+                        config_dir,
+                        config_response.get_child_id()
+                    ),
+                    "tedge",
+                    "tedge",
+                    0o755,
+                    None,
+                )?;
+                // copy to /etc/c8y
+                let path_from = &format!(
+                    "/var/tedge/file-transfer/{}/c8y-configuration-plugin",
+                    config_response.get_child_id()
+                );
+                let path_from = Path::new(path_from);
+                let path_to = &format!(
+                    "{}/c8y/{}/c8y-configuration-plugin.toml",
+                    config_dir,
+                    config_response.get_child_id()
+                );
+                let path_to = Path::new(path_to);
+                std::fs::rename(path_from, path_to)?;
+            }
+            // send 119
+            let child_plugin_config = PluginConfig::new(Path::new(&format!(
+                "{}/c8y/{}/c8y-configuration-plugin.toml",
+                config_dir,
+                config_response.get_child_id()
+            )));
+
+            // Publish supported configuration types for child devices
+            let message = child_plugin_config
+                .to_supported_config_types_message_for_child(&config_response.get_child_id())?;
+            Ok(vec![message])
+        }
+    }
+
+    pub async fn handle_child_device_successful_config_snapshot_response(
+        &mut self,
+        config_response: &ConfigOperationResponse,
+        message_box: &mut ConfigManagerMessageBox,
+    ) -> Result<Message, anyhow::Error> {
+        let c8y_child_topic = Topic::new_unchecked(&config_response.get_child_topic());
+
+        let uploaded_config_file_path = config_response.file_transfer_repository_full_path();
+
+        let c8y_upload_event_url = self
+            .upload_config_file(
+                Path::new(&uploaded_config_file_path),
+                &config_response.get_config_type(),
+                Some(config_response.get_child_id()),
+                message_box,
+            )
+            .await?;
+
+        // Cleanup the child uploaded file after uploading it to cloud
+        try_cleanup_config_file_from_file_transfer_repositoy(config_response);
+
+        info!("Marking the c8y_UploadConfigFile operation as successful with the Cumulocity URL for the uploaded file: {c8y_upload_event_url}");
+        let successful_status_payload =
+            UploadConfigFileStatusMessage::status_successful(Some(c8y_upload_event_url))?;
+        let message = Message::new(&c8y_child_topic, successful_status_payload);
+
+        Ok(message)
+    }
+
     pub async fn upload_config_file(
         &mut self,
         config_file_path: &Path,
         config_type: &str,
+        child_device_id: Option<String>,
         message_box: &mut ConfigManagerMessageBox,
     ) -> Result<String> {
         let url = message_box
             .c8y_http_proxy
-            .upload_config_file(config_file_path, config_type, None)
-            .await
-            .unwrap();
+            .upload_config_file(config_file_path, config_type, child_device_id)
+            .await?;
         Ok(url)
     }
 }
@@ -127,4 +363,11 @@ impl TryIntoOperationStatusMessage for UploadConfigFileStatusMessage {
         )
         .to_smartrest()
     }
+}
+
+#[cfg(test)]
+mod tests {
+
+    #[test]
+    fn test() {}
 }

--- a/crates/bin/c8y_configuration_poc/src/main.rs
+++ b/crates/bin/c8y_configuration_poc/src/main.rs
@@ -20,6 +20,7 @@ use tedge_http_ext::HttpActorBuilder;
 use tedge_http_ext::HttpConfig;
 use tedge_mqtt_ext::MqttActorBuilder;
 use tedge_signal_ext::SignalActor;
+use tedge_timer_ext::TimerActor;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
@@ -37,6 +38,7 @@ async fn main() -> anyhow::Result<()> {
         C8YHttpProxyBuilder::new(tedge_config.try_into()?, &mut http_actor, &mut jwt_actor);
     let mut fs_watch_actor = FsWatchActorBuilder::new();
     let mut signal_actor = SignalActor::builder();
+    let mut timer_actor = TimerActor::builder();
 
     //Instantiate config manager actor
     let mut config_actor =
@@ -46,6 +48,7 @@ async fn main() -> anyhow::Result<()> {
     config_actor.with_fs_connection(&mut fs_watch_actor)?;
     config_actor.with_c8y_http_proxy(&mut c8y_http_proxy_actor)?;
     config_actor.with_mqtt_connection(&mut mqtt_actor)?;
+    config_actor.with_timer(&mut timer_actor)?;
 
     //Instantiate log manager actor
     let mut log_actor = LogManagerBuilder::new(LogManagerConfig::from_default_tedge_config()?);
@@ -68,6 +71,7 @@ async fn main() -> anyhow::Result<()> {
     runtime.spawn(fs_watch_actor).await?;
     runtime.spawn(config_actor).await?;
     runtime.spawn(log_actor).await?;
+    runtime.spawn(timer_actor).await?;
 
     runtime.run_to_completion().await?;
     Ok(())

--- a/crates/extensions/tedge_timer_ext/src/builder.rs
+++ b/crates/extensions/tedge_timer_ext/src/builder.rs
@@ -14,6 +14,9 @@ use tedge_actors::Message;
 use tedge_actors::MessageBoxPlug;
 use tedge_actors::MessageBoxSocket;
 use tedge_actors::NoConfig;
+use tedge_actors::NullSender;
+use tedge_actors::RuntimeRequest;
+use tedge_actors::RuntimeRequestSink;
 use tedge_actors::Sender;
 use tedge_actors::ServiceMessageBoxBuilder;
 use tokio::sync::Mutex;
@@ -41,6 +44,13 @@ impl Builder<(TimerActor, <TimerActor as Actor>::MessageBox)> for TimerActorBuil
         let actor = TimerActor::default();
         let actor_box = self.box_builder.build();
         (actor, actor_box)
+    }
+}
+
+impl RuntimeRequestSink for TimerActorBuilder {
+    fn get_signal_sender(&self) -> DynSender<RuntimeRequest> {
+        // FIXME: this actor should not ignore runtime requests
+        NullSender.into()
     }
 }
 

--- a/crates/extensions/tedge_timer_ext/src/messages.rs
+++ b/crates/extensions/tedge_timer_ext/src/messages.rs
@@ -10,6 +10,12 @@ pub struct SetTimeout<T: Message> {
     pub event: T,
 }
 
+impl<T: Message> SetTimeout<T> {
+    pub fn new(duration: Duration, event: T) -> Self {
+        Self { duration, event }
+    }
+}
+
 /// Timeout event sent by the timer back to the caller
 #[derive(Debug)]
 pub struct Timeout<T: Message> {


### PR DESCRIPTION
## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the
maintainers why we should accept this pull request. If it fixes a bug or
resolves a feature request, be sure to link to that issue.
-->

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [ ] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [ ] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

